### PR TITLE
Update reek & rubocop versions

### DIFF
--- a/our_ruby_style.gemspec
+++ b/our_ruby_style.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'fasterer', '0.4.1'
   spec.add_runtime_dependency 'rails', '~> 5.0'
-  spec.add_runtime_dependency 'reek', '~> 1.4'
-  spec.add_runtime_dependency 'rubocop', '~> 0.53'
+  spec.add_runtime_dependency 'reek', '~> 4.8.1'
+  spec.add_runtime_dependency 'rubocop', '~> 0.68.0'
   spec.add_runtime_dependency 'thor', '~> 0.20'
 end


### PR DESCRIPTION
Update gems ('reek', '~> 4.8.1 & 'rubocop', '~> 0.68.0')